### PR TITLE
removed useless typecomputer case

### DIFF
--- a/edelta.parent/edelta/src/edelta/typesystem/EdeltaTypeComputer.xtend
+++ b/edelta.parent/edelta/src/edelta/typesystem/EdeltaTypeComputer.xtend
@@ -38,7 +38,7 @@ class EdeltaTypeComputer extends XbaseWithAnnotationsTypeComputer {
 	def void _computeTypes(EdeltaEcoreReference e, ITypeComputationState state) {
 		val enamedelement = e.enamedelement;
 		val type = switch (enamedelement) {
-			case enamedelement === null || enamedelement.eIsProxy: {
+			case enamedelement.eIsProxy: {
 				// if it's unresolved, but there's a type expectation, then
 				// we assign to this reference the expected type: this way
 				// we will only get an error due to unresolved reference


### PR DESCRIPTION
The enamedelement of an EdeltaEcoreReferece cannot be null in the
typecomputer, since we check for that when typing an
EdeltaEcoreReferenceExpression