### PR TITLE
Explicit <pomDependencies>ignore</pomDependencies>

### DIFF
--- a/edelta.parent/pom.xml
+++ b/edelta.parent/pom.xml
@@ -347,6 +347,7 @@
               <version>${project.version}</version>
             </artifact>
           </target>
+          <pomDependencies>ignore</pomDependencies>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Without this explicit configuration, after target platform has been resolved in the past we get this error:

```
[INFO] Computing target platform for MavenProject: io.github.lorenzobettini.edelta:edelta:2.2.0-SNAPSHOT @ /home/runner/work/edelta/edelta/edelta.parent/edelta/pom.xml
[INFO] Maven Artifact com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava is not a bundle and will be ignored, automatic wrapping of such artifacts can be enabled with <pomDependencies>use</pomDependencies> in target platform configuration.
[INFO] Maven Artifact org.checkerframework:checker-qual:2.5.2 is not a bundle and will be ignored, automatic wrapping of such artifacts can be enabled with <pomDependencies>use</pomDependencies> in target platform configuration.
[INFO] Maven Artifact com.google.errorprone:error_prone_annotations:2.2.0 is not a bundle and will be ignored, automatic wrapping of such artifacts can be enabled with <pomDependencies>use</pomDependencies> in target platform configuration.
[INFO] Maven Artifact com.google.j2objc:j2objc-annotations:1.1 is not a bundle and will be ignored, automatic wrapping of such artifacts can be enabled with <pomDependencies>use</pomDependencies> in target platform configuration.
[INFO] Maven Artifact org.codehaus.mojo:animal-sniffer-annotations:1.17 is not a bundle and will be ignored, automatic wrapping of such artifacts can be enabled with <pomDependencies>use</pomDependencies> in target platform configuration.
Error:  Internal error: java.lang.RuntimeException: Only one of the p2 data artifacts p2metadata.xml/p2artifacts.xml of the POM dependency org.eclipse.emf:org.eclipse.emf.mwe2.runtime:2.12.0 could be resolved -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: java.lang.RuntimeException: Only one of the p2 data artifacts p2metadata.xml/p2artifacts.xml of the POM dependency org.eclipse.emf:org.eclipse.emf.mwe2.runtime:2.12.0 could be resolved
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:120)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.maven.wrapper.BootstrapMainStarter.start (BootstrapMainStarter.java:39)
    at org.apache.maven.wrapper.WrapperExecutor.execute (WrapperExecutor.java:122)
    at org.apache.maven.wrapper.MavenWrapperMain.main (MavenWrapperMain.java:61)
Caused by: java.lang.RuntimeException: Only one of the p2 data artifacts p2metadata.xml/p2artifacts.xml of the POM dependency org.eclipse.emf:org.eclipse.emf.mwe2.runtime:2.12.0 could be resolved
    at org.eclipse.tycho.p2.resolver.PomDependencyProcessor.failDueToPartialP2Data (PomDependencyProcessor.java:110)
    at org.eclipse.tycho.p2.resolver.PomDependencyProcessor.collectPomDependencies (PomDependencyProcessor.java:95)
    at org.eclipse.tycho.p2.resolver.P2DependencyResolver.collectPomDependencies (P2DependencyResolver.java:291)
    at org.eclipse.tycho.p2.resolver.P2DependencyResolver.computePreliminaryTargetPlatform (P2DependencyResolver.java:201)
    at org.eclipse.tycho.core.resolver.DefaultTychoResolver.resolveProject (DefaultTychoResolver.java:119)
    at org.eclipse.tycho.core.maven.TychoMavenLifecycleParticipant.afterProjectsRead (TychoMavenLifecycleParticipant.java:95)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:264)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.maven.wrapper.BootstrapMainStarter.start (BootstrapMainStarter.java:39)
    at org.apache.maven.wrapper.WrapperExecutor.execute (WrapperExecutor.java:122)
    at org.apache.maven.wrapper.MavenWrapperMain.main (MavenWrapperMain.java:61)
```