### PR TITLE
GitHub actions cache

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,8 +27,8 @@ jobs:
           ~/.m2
           ~/.sonar/cache
           !**/*edelta*
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        key: m2-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: m2-${{ runner.os }}-
     - name: Build with Maven and SonarCloud
       run: >
         xvfb-run

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
           ~/.sonar/cache
           !**/*edelta*
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2-
+        restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven and SonarCloud
       run: >
         xvfb-run

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
           ~/.sonar/cache
           !**/*edelta*
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2-
+        restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
       run: ./mvnw -f edelta.parent/pom.xml -U clean verify -Pbuild-ide,test-ide,run-its
       if: runner.os == 'macOS'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,17 +1,13 @@
 # This workflow will build a Java project with Maven
-# This runs only on PR (also when the PR is merged:
-# this way also caches for macos and windows are updated
-# in the master branch)
+# This runs only on PR
 
 name: Java CI with Maven
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
 
 jobs:
   build:
-    if: github.event.action != 'closed' || github.event.pull_request.merged == true
     strategy:
       matrix:
         os: ['macos-latest', 'windows-latest']

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,8 +26,10 @@ jobs:
           ~/.m2
           ~/.sonar/cache
           !**/*edelta*
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        key: m2-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          m2-${{ runner.os }}-
+          m2-
     - name: Build with Maven
       run: ./mvnw -f edelta.parent/pom.xml -U clean verify -Pbuild-ide,test-ide,run-its
       if: runner.os == 'macOS'


### PR DESCRIPTION
starting with "m2" and then the "runner-os". This way, when building on
Windows and Mac we should be able to start from the main cache file from
the upstream branch created when building on Linux