### PR TITLE
Simplify model migrator

### DIFF
--- a/edelta.parent/edelta.lib.tests/src/edelta/lib/tests/EdeltaModelManagerTest.java
+++ b/edelta.parent/edelta.lib.tests/src/edelta/lib/tests/EdeltaModelManagerTest.java
@@ -129,20 +129,17 @@ public class EdeltaModelManagerTest {
 		var additionalModelManager = new EdeltaModelManager();
 		var prototypeEcoreResource =
 			(XMIResource) additionalModelManager.loadEcoreFile(TESTDATA+SIMPLE_TEST_DATA+MY_ECORE);
-		var prototypeModelResource =
+		var prototypeMyClassModelResource =
 			(XMIResource) additionalModelManager.loadModelFile(TESTDATA+SIMPLE_TEST_DATA+MY_CLASS);
+		var prototypeMyRootModelResource =
+			(XMIResource) additionalModelManager.loadModelFile(TESTDATA+SIMPLE_TEST_DATA+MY_ROOT);
 
-		// note that we use the same prototypeResource to create the
-		// two new resources, since we're only interested in the prototype's
-		// options and encoding. In this test this should be enough,
-		// since the models we create are based on the same ecore
-		modelManager.createEcoreResource(TESTDATA+SIMPLE_TEST_DATA+MY_ECORE,
-				prototypeEcoreResource);
+		modelManager.createEcoreResource(prototypeEcoreResource);
 		modelManager.loadEcoreFile(TESTDATA+SIMPLE_TEST_DATA+MY_ECORE);
 		var myClassModelResource = modelManager
-			.createModelResource(TESTDATA+SIMPLE_TEST_DATA+MY_CLASS, prototypeModelResource);
+			.createModelResource(prototypeMyClassModelResource);
 		var myRootModelResource = modelManager
-			.createModelResource(TESTDATA+SIMPLE_TEST_DATA+MY_ROOT, prototypeModelResource);
+			.createModelResource(prototypeMyRootModelResource);
 		var myClassEClass = (EClass)
 			modelManager.getEPackage(MYPACKAGE).getEClassifier("MyClass");
 		myClassModelResource.getContents().add(EcoreUtil.create(myClassEClass));
@@ -187,7 +184,7 @@ public class EdeltaModelManagerTest {
 		var ecoreResource =
 			(XMIResource) otherModelManager.loadEcoreFile(TESTDATA+SIMPLE_TEST_DATA+MY_ECORE);
 
-		var map = modelManager.copyEcores(otherModelManager, TESTDATA+SIMPLE_TEST_DATA);
+		var map = modelManager.copyEcores(otherModelManager);
 
 		Iterable<EObject> originalContents = () -> 
 			EcoreUtil.getAllContents(ecoreResource, true);

--- a/edelta.parent/edelta.lib.tests/src/edelta/lib/tests/EdeltaModelMigratorTest.java
+++ b/edelta.parent/edelta.lib.tests/src/edelta/lib/tests/EdeltaModelMigratorTest.java
@@ -66,6 +66,8 @@ class EdeltaModelMigratorTest {
 	 */
 	EdeltaModelManager evolvingModelManager;
 
+	private String basedir;
+
 	@BeforeAll
 	static void clearOutput() throws IOException {
 		cleanDirectoryRecursive(OUTPUT);
@@ -82,7 +84,7 @@ class EdeltaModelMigratorTest {
 			Collection<String> ecoreFiles,
 			Collection<String> modelFiles
 		) {
-		var basedir = TESTDATA + subdir;
+		basedir = TESTDATA + subdir;
 		ecoreFiles
 			.forEach(fileName -> originalModelManager.loadEcoreFile(basedir + fileName));
 		modelFiles
@@ -112,7 +114,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
 		);
@@ -129,7 +130,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -149,7 +149,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("My1.ecore", "My2.ecore"),
 			of("MyRoot1.xmi", "MyClass1.xmi", "MyRoot2.xmi", "MyClass2.xmi")
 		);
@@ -167,7 +166,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonForReferences.ecore", "WorkPlaceForReferences.ecore"),
 			of("Person1.xmi", "Person2.xmi", "WorkPlace1.xmi")
@@ -192,7 +190,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"renamedClass/",
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
@@ -219,7 +216,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"renamedFeature/",
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
@@ -242,7 +238,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"mutualReferencesRenamed/",
 			of("PersonForReferences.ecore", "WorkPlaceForReferences.ecore"),
 			of("Person1.xmi", "Person2.xmi", "WorkPlace1.xmi")
@@ -271,7 +266,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"mutualReferencesRenamed2/",
 			of("PersonForReferences.ecore", "WorkPlaceForReferences.ecore"),
 			of("Person1.xmi", "Person2.xmi", "WorkPlace1.xmi")
@@ -294,7 +288,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"removedContainmentFeature/",
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
@@ -317,7 +310,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"removedNonContainmentFeature/",
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
@@ -340,7 +332,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"removedNonReferredClass/",
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
@@ -363,7 +354,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"removedReferredClass/",
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
@@ -389,7 +379,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -417,7 +406,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"toUpperCaseSingleAttribute/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -446,7 +434,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"toUpperCaseSingleAttributeAndRenamedBefore/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -475,7 +462,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"toUpperCaseSingleAttributeAndRenamedBefore/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -505,7 +491,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"toUpperCaseSingleAttributeAndMakeMultiple/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -536,7 +521,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"toUpperCaseSingleAttributeAndMakeMultiple/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -564,7 +548,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -594,7 +577,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"toUpperCaseSingleAttributeMultipleAndMakeSingle/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -624,7 +606,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"toUpperCaseSingleAttributeMultipleAndMakeSingle/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -648,7 +629,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeSingle/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -672,7 +652,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeMultiple/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -696,7 +675,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeMultipleTo2/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -722,7 +700,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeMultipleAndMakeSingle/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -755,7 +732,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeSingleAndMakeMultiple/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -779,7 +755,6 @@ class EdeltaModelMigratorTest {
 	
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeSingleNonContainmentReference/",
 			of("My.ecore"),
 			of("MyRoot.xmi")
@@ -810,7 +785,6 @@ class EdeltaModelMigratorTest {
 	
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeSingleContainmentReference/",
 			of("My.ecore"),
 			of("MyRoot.xmi")
@@ -834,7 +808,6 @@ class EdeltaModelMigratorTest {
 	
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeMultipleNonContainmentReference/",
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
@@ -858,7 +831,6 @@ class EdeltaModelMigratorTest {
 	
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeMultipleContainmentReference/",
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
@@ -884,7 +856,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeMultipleAndMakeSingleNonContainmentReference/",
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
@@ -917,7 +888,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeSingleAndMakeMultipleNonContainmentReference/",
 			of("My.ecore"),
 			of("MyRoot.xmi")
@@ -943,7 +913,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeMultipleAndMakeSingleContainmentReference/",
 			of("My.ecore"),
 			of("MyRoot.xmi", "MyClass.xmi")
@@ -980,7 +949,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"makeSingleAndMakeMultipleContainmentReference/",
 			of("My.ecore"),
 			of("MyRoot.xmi")
@@ -1004,7 +972,6 @@ class EdeltaModelMigratorTest {
 		Assertions.assertThatThrownBy(() -> // NOSONAR
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"should not get here/",
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -1053,7 +1020,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
 		);
@@ -1087,7 +1053,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
 		);
@@ -1120,7 +1085,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -1166,7 +1130,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"changedAttributeTypeAndMultiplicity/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -1202,7 +1165,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"changedAttributeTypeAndMultiplicity/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -1238,7 +1200,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"changedAttributeTypeAndMultiplicity/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -1274,7 +1235,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"changedAttributeTypeAndMultiplicity/",
 			of("My.ecore"),
 			of("MyClass.xmi", "MyClass2.xmi", "MyClass3.xmi")
@@ -1315,7 +1275,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("My.ecore"),
 			of("MyClass.xmi")
 		);
@@ -1349,7 +1308,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("My.ecore"),
 			of("MyClass.xmi")
 		);
@@ -1382,7 +1340,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -1418,7 +1375,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"changedMultiAttributeTypeAndMultiplicity/",
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -1454,7 +1410,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"changedMultiAttributeTypeAndMultiplicity/",
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -1490,7 +1445,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"changedMultiAttributeTypeAndMultiplicityTo2/",
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -1526,7 +1480,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"changedMultiAttributeTypeAndMultiplicityTo2/",
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -1561,7 +1514,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"changedAttributeNameAndType/",
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -1599,7 +1551,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"changedAttributeTypeAndName/",
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -1675,7 +1626,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"replaceWithCopy/",
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -1700,7 +1650,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"replaceWithCopyTwice/",
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -1739,7 +1688,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
 		);
@@ -1768,7 +1716,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -1799,7 +1746,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
 		);
@@ -1829,7 +1775,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -1864,7 +1809,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"pullUpAndPushDown/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -1898,7 +1842,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"pushDownAndPullUp/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -1927,7 +1870,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
 		);
@@ -1954,7 +1896,6 @@ class EdeltaModelMigratorTest {
 	
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2025,7 +1966,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("My.ecore"),
 			of("MyRoot.xmi")
 		);
@@ -2092,7 +2032,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("My.ecore"),
 			of("MyRoot.xmi")
@@ -2166,7 +2105,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("My.ecore"),
 			of("MyRoot.xmi")
 		);
@@ -2214,7 +2152,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"replaceWithCopy/",
 			of("My.ecore"),
 			of("MyClass.xmi")
@@ -2273,7 +2210,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"replaceWithCopy/",
 			of("My.ecore"),
 			of("MyRoot.xmi")
@@ -2307,7 +2243,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
 		);
@@ -2331,7 +2266,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
 		);
@@ -2354,7 +2288,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2386,7 +2319,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"referenceToClassMultipleBidirectionalChangedIntoSingleMain/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2424,7 +2356,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"referenceToClassMultipleBidirectionalChangedIntoSingleOpposite/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2462,7 +2393,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"referenceToClassMultipleBidirectionalChangedIntoSingleOpposite/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2499,7 +2429,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"referenceToClassMultipleBidirectionalChangedIntoSingleBoth/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2536,7 +2465,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"referenceToClassMultipleBidirectionalChangedIntoSingleBoth/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2568,7 +2496,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
 		);
@@ -2597,7 +2524,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"referenceToClassUnidirectional/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2622,7 +2548,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"classToReferenceUnidirectional/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2647,7 +2572,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"referenceToClassBidirectional/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2672,7 +2596,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"classToReferenceBidirectional/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2697,7 +2620,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"referenceToClassBidirectional/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2722,7 +2644,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"classToReferenceBidirectional/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2765,7 +2686,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("Person.ecore"),
 			of("Person.xmi")
 		);
@@ -2794,7 +2714,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"mergeAttributesWithoutValueMerger/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2829,7 +2748,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2878,7 +2796,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -2954,7 +2871,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -3047,7 +2963,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
 		);
@@ -3082,7 +2997,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -3132,7 +3046,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -3204,7 +3117,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -3296,7 +3208,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
 		);
@@ -3354,7 +3265,6 @@ class EdeltaModelMigratorTest {
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
 			subdir,
-			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
 		);
@@ -3410,7 +3320,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -3485,7 +3394,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -3594,7 +3502,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"splitFeatureNonContainment/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -3735,7 +3642,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"splitFeatureNonContainmentShared/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -3817,7 +3723,6 @@ class EdeltaModelMigratorTest {
 	
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -3927,7 +3832,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -4065,7 +3969,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"mergeFeaturesNonContainmentShared/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -4088,7 +3991,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -4114,7 +4016,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			subdir,
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -4144,7 +4045,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"subclassesToEnum/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -4173,7 +4073,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"enumToSubclasses/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -4243,7 +4142,6 @@ class EdeltaModelMigratorTest {
 
 		copyModelsSaveAndAssertOutputs(
 			modelMigrator,
-			subdir,
 			"composeOperations1/",
 			of("PersonList.ecore"),
 			of("List.xmi")
@@ -4252,12 +4150,10 @@ class EdeltaModelMigratorTest {
 
 	private void copyModelsSaveAndAssertOutputs(
 			EdeltaModelMigrator modelMigrator,
-			String origdir,
 			String outputdir,
 			Collection<String> ecoreFiles,
 			Collection<String> modelFiles
 		) throws IOException {
-		var basedir = TESTDATA + origdir;
 		copyModels(modelMigrator, basedir);
 		var output = OUTPUT + outputdir;
 		evolvingModelManager.saveEcores(output);

--- a/edelta.parent/edelta.lib.tests/src/edelta/lib/tests/EdeltaModelMigratorTest.java
+++ b/edelta.parent/edelta.lib.tests/src/edelta/lib/tests/EdeltaModelMigratorTest.java
@@ -4154,7 +4154,7 @@ class EdeltaModelMigratorTest {
 			Collection<String> ecoreFiles,
 			Collection<String> modelFiles
 		) throws IOException {
-		copyModels(modelMigrator, basedir);
+		copyModels(modelMigrator, "");
 		var output = OUTPUT + outputdir;
 		evolvingModelManager.saveEcores(output);
 		evolvingModelManager.saveModels(output);

--- a/edelta.parent/edelta.lib.tests/src/edelta/lib/tests/EdeltaModelMigratorTest.java
+++ b/edelta.parent/edelta.lib.tests/src/edelta/lib/tests/EdeltaModelMigratorTest.java
@@ -87,7 +87,8 @@ class EdeltaModelMigratorTest {
 			.forEach(fileName -> originalModelManager.loadEcoreFile(basedir + fileName));
 		modelFiles
 			.forEach(fileName -> originalModelManager.loadModelFile(basedir + fileName));
-		var modelMigrator = new EdeltaModelMigrator(basedir, originalModelManager, evolvingModelManager);
+		var modelMigrator = new EdeltaModelMigrator(basedir, originalModelManager);
+		evolvingModelManager = modelMigrator.getEvolvingModelManager();
 		return modelMigrator;
 	}
 

--- a/edelta.parent/edelta.lib.tests/src/edelta/lib/tests/EdeltaModelMigratorTest.java
+++ b/edelta.parent/edelta.lib.tests/src/edelta/lib/tests/EdeltaModelMigratorTest.java
@@ -5,7 +5,13 @@ import static edelta.testutils.EdeltaTestUtils.cleanDirectoryRecursive;
 import static java.util.Arrays.asList;
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -31,7 +37,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcorePackage;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.junit.jupiter.api.BeforeAll;
@@ -89,7 +94,7 @@ class EdeltaModelMigratorTest {
 			.forEach(fileName -> originalModelManager.loadEcoreFile(basedir + fileName));
 		modelFiles
 			.forEach(fileName -> originalModelManager.loadModelFile(basedir + fileName));
-		var modelMigrator = new EdeltaModelMigrator(basedir, originalModelManager);
+		var modelMigrator = new EdeltaModelMigrator(originalModelManager);
 		evolvingModelManager = modelMigrator.getEvolvingModelManager();
 		return modelMigrator;
 	}
@@ -4154,7 +4159,7 @@ class EdeltaModelMigratorTest {
 			Collection<String> ecoreFiles,
 			Collection<String> modelFiles
 		) throws IOException {
-		copyModels(modelMigrator, "");
+		copyModels(modelMigrator);
 		var output = OUTPUT + outputdir;
 		evolvingModelManager.saveEcores(output);
 		evolvingModelManager.saveModels(output);
@@ -4198,18 +4203,9 @@ class EdeltaModelMigratorTest {
 
 	/**
 	 * This simulates what the final model migration should do.
-	 * 
-	 * IMPORTANT: the original Ecores and models must be in a subdirectory
-	 * of the directory that stores the modified Ecores.
-	 * 
-	 * It is crucial to strip the original path and use the baseDir
-	 * to create the new {@link Resource} URI, so that, upon saving,
-	 * the schema location is computed correctly.
-	 * 
-	 * @param baseDir
 	 */
-	private void copyModels(EdeltaModelMigrator modelMigrator, String baseDir) {
-		modelMigrator.copyModels(baseDir);
+	private void copyModels(EdeltaModelMigrator modelMigrator) {
+		modelMigrator.copyModels();
 	}
 
 	// SIMULATION OF REFACTORINGS THAT WILL BE PART OF OUR LIBRARY LATER

--- a/edelta.parent/edelta.lib/src/edelta/lib/EdeltaModelManager.java
+++ b/edelta.parent/edelta.lib/src/edelta/lib/EdeltaModelManager.java
@@ -199,9 +199,9 @@ public class EdeltaModelManager {
 	 * @return
 	 */
 	private Resource createResource(String path, XMIResource prototypeResource, Collection<Resource> resourceMap) {
-		var uri = createAbsoluteFileURI(path);
-		LOG.info("Creating " + path + " (URI: " + uri + ")");
-		var resource = (XMIResource) resourceSet.createResource(uri);
+		var originalURI = prototypeResource.getURI();
+		LOG.info("Creating " + originalURI);
+		var resource = (XMIResource) resourceSet.createResource(originalURI);
 		resource.getDefaultLoadOptions().putAll(prototypeResource.getDefaultLoadOptions());
 		resource.getDefaultSaveOptions().putAll(prototypeResource.getDefaultSaveOptions());
 		resource.setEncoding(prototypeResource.getEncoding());

--- a/edelta.parent/edelta.lib/src/edelta/lib/EdeltaModelManager.java
+++ b/edelta.parent/edelta.lib/src/edelta/lib/EdeltaModelManager.java
@@ -168,12 +168,11 @@ public class EdeltaModelManager {
 	 * using the passed resource as a "prototype": it takes all its options and
 	 * encoding.
 	 * 
-	 * @param path
 	 * @param prototypeResource
 	 * @return
 	 */
-	public Resource createEcoreResource(String path, XMIResource prototypeResource) {
-		return createResource(path, prototypeResource, ecoreResources);
+	public Resource createEcoreResource(XMIResource prototypeResource) {
+		return createResource(prototypeResource, ecoreResources);
 	}
 
 	/**
@@ -181,24 +180,22 @@ public class EdeltaModelManager {
 	 * using the passed resource as a "prototype": it takes all its options and
 	 * encoding.
 	 * 
-	 * @param path
 	 * @param prototypeResource
 	 * @return
 	 */
-	public Resource createModelResource(String path, XMIResource prototypeResource) {
-		return createResource(path, prototypeResource, modelResources);
+	public Resource createModelResource(XMIResource prototypeResource) {
+		return createResource(prototypeResource, modelResources);
 	}
 
 	/**
 	 * Create a new {@link XMIResource} in the {@link ResourceSet}, using the passed
 	 * resource as a "prototype": it takes all its options and encoding.
 	 * 
-	 * @param path
 	 * @param prototypeResource
 	 * @param resourceMap 
 	 * @return
 	 */
-	private Resource createResource(String path, XMIResource prototypeResource, Collection<Resource> resourceMap) {
+	private Resource createResource(XMIResource prototypeResource, Collection<Resource> resourceMap) {
 		var originalURI = prototypeResource.getURI();
 		LOG.info("Creating " + originalURI);
 		var resource = (XMIResource) resourceSet.createResource(originalURI);
@@ -228,14 +225,12 @@ public class EdeltaModelManager {
 		return ecoreResources;
 	}
 
-	public Map<EObject, EObject> copyEcores(EdeltaModelManager otherModelManager, String basedir) {
+	public Map<EObject, EObject> copyEcores(EdeltaModelManager otherModelManager) {
 		var otherEcoreResources = otherModelManager.getEcoreResources();
 		var ecoreCopier = new Copier();
 		for (var resource : otherEcoreResources) {
 			var originalResource = (XMIResource) resource;
-			var fileName = EdeltaResourceUtils.getFileName(originalResource);
-			var newResource = this.createEcoreResource
-				(basedir + fileName, originalResource);
+			var newResource = this.createEcoreResource(originalResource);
 			var root = originalResource.getContents().get(0);
 			newResource.getContents().add(ecoreCopier.copy(root));
 		}

--- a/edelta.parent/edelta.lib/src/edelta/lib/EdeltaModelMigrator.java
+++ b/edelta.parent/edelta.lib/src/edelta/lib/EdeltaModelMigrator.java
@@ -17,7 +17,6 @@ import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EStructuralFeature.Setting;
 import org.eclipse.emf.ecore.InternalEObject;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil.Copier;
 import org.eclipse.emf.ecore.xmi.XMIResource;
 import org.eclipse.xtext.xbase.lib.Functions.Function3;
@@ -180,13 +179,6 @@ public class EdeltaModelMigrator {
 
 	/**
 	 * This simulates what the final model migration should do.
-	 * 
-	 * IMPORTANT: the original Ecores and models must be in a subdirectory
-	 * of the directory that stores the modified Ecores.
-	 * 
-	 * It is crucial to strip the original path and use the baseDir
-	 * to create the new {@link Resource} URI, so that, upon saving,
-	 * the schema location is computed correctly.
 	 * 
 	 * @param baseDir
 	 */

--- a/edelta.parent/edelta.lib/src/edelta/lib/EdeltaModelMigrator.java
+++ b/edelta.parent/edelta.lib/src/edelta/lib/EdeltaModelMigrator.java
@@ -131,7 +131,6 @@ public class EdeltaModelMigrator {
 		}
 	}
 
-	private String basedir;
 	private EdeltaModelManager originalModelManager;
 	private EdeltaModelManager evolvingModelManager;
 	private Map<EObject, EObject> mapOfCopiedEcores;
@@ -163,12 +162,10 @@ public class EdeltaModelMigrator {
 			extends Function<EObject, EObject> {
 	}
 
-	public EdeltaModelMigrator(String basedir,
-			EdeltaModelManager originalModelManager) {
-		this.basedir = basedir;
+	public EdeltaModelMigrator(EdeltaModelManager originalModelManager) {
 		this.originalModelManager = originalModelManager;
 		this.evolvingModelManager = new EdeltaModelManager();
-		this.mapOfCopiedEcores = evolvingModelManager.copyEcores(originalModelManager, basedir);
+		this.mapOfCopiedEcores = evolvingModelManager.copyEcores(originalModelManager);
 		this.modelCopier = new EdeltaModelCopier(
 				mapOfCopiedEcores);
 	}
@@ -179,21 +176,16 @@ public class EdeltaModelMigrator {
 
 	/**
 	 * This simulates what the final model migration should do.
-	 * 
-	 * @param baseDir
 	 */
-	public void copyModels(String baseDir) {
-		copyModels(modelCopier, baseDir, originalModelManager, evolvingModelManager);
+	public void copyModels() {
+		copyModels(modelCopier, originalModelManager, evolvingModelManager);
 	}
 
-	private void copyModels(EdeltaModelCopier edeltaModelCopier, String baseDir,
-			EdeltaModelManager from, EdeltaModelManager into) {
+	private void copyModels(EdeltaModelCopier edeltaModelCopier, EdeltaModelManager from, EdeltaModelManager into) {
 		var models = from.getModelResources();
 		for (var resource : models) {
 			var originalResource = (XMIResource) resource;
-			var fileName = EdeltaResourceUtils.getFileName(originalResource);
-			var newResource = into.createModelResource
-				(baseDir + fileName, originalResource);
+			var newResource = into.createModelResource(originalResource);
 			var root = originalResource.getContents().get(0);
 			var copy = edeltaModelCopier.copy(root);
 			if (copy != null)
@@ -215,8 +207,7 @@ public class EdeltaModelMigrator {
 				super.copyAttributeValue(eAttribute, eObject, value, setting);
 			}
 		};
-		copyModels(modelCopier, basedir,
-				originalModelManager, evolvingModelManager);
+		copyModels(modelCopier, originalModelManager, evolvingModelManager);
 		updateMigrationContext();
 	}
 
@@ -234,8 +225,7 @@ public class EdeltaModelMigrator {
 				super.copyAttributeValue(eAttribute, eObject, value, setting);
 			}
 		};
-		copyModels(modelCopier, basedir,
-				originalModelManager, evolvingModelManager);
+		copyModels(modelCopier, originalModelManager, evolvingModelManager);
 		updateMigrationContext();
 	}
 
@@ -279,8 +269,7 @@ public class EdeltaModelMigrator {
 					runnable.run();
 			}
 		};
-		copyModels(modelCopier, basedir,
-				originalModelManager, evolvingModelManager);
+		copyModels(modelCopier, originalModelManager, evolvingModelManager);
 		if (postCopy != null)
 			postCopy.run();
 		updateMigrationContext();
@@ -302,8 +291,7 @@ public class EdeltaModelMigrator {
 					: ((InternalEObject) copyEObject).eSetting(targetEStructuralFeature);
 			}
 		};
-		copyModels(modelCopier, basedir,
-				originalModelManager, evolvingModelManager);
+		copyModels(modelCopier, originalModelManager, evolvingModelManager);
 		updateMigrationContext();
 	}
 
@@ -319,8 +307,7 @@ public class EdeltaModelMigrator {
 				return super.createCopy(eObject);
 			}
 		};
-		copyModels(modelCopier, basedir,
-				originalModelManager, evolvingModelManager);
+		copyModels(modelCopier, originalModelManager, evolvingModelManager);
 		updateMigrationContext();
 	}
 
@@ -330,11 +317,11 @@ public class EdeltaModelMigrator {
 		// first create a copy of the evolved ecores
 		// map: orig -> copy
 		// orig are the evolved ecores, copy are the backup Ecores
-		var map = backup.copyEcores(evolvingModelManager, basedir);
+		var map = backup.copyEcores(evolvingModelManager);
 		// now create a copy of the evolved models
 		// we have to use our custom Copier because that will correctly
 		// create copies of models referring to the backup ecores
-		copyModels(new EdeltaModelCopier(map), basedir, evolvingModelManager, backup);
+		copyModels(new EdeltaModelCopier(map), evolvingModelManager, backup);
 		// now we need an inverted map, because the backup is meant to become the
 		// new originals, for the next model migrations
 		mapOfCopiedEcores = HashBiMap.create(map).inverse();

--- a/edelta.parent/edelta.lib/src/edelta/lib/EdeltaModelMigrator.java
+++ b/edelta.parent/edelta.lib/src/edelta/lib/EdeltaModelMigrator.java
@@ -165,14 +165,17 @@ public class EdeltaModelMigrator {
 	}
 
 	public EdeltaModelMigrator(String basedir,
-			EdeltaModelManager originalModelManager,
-			EdeltaModelManager evolvingModelManager) {
+			EdeltaModelManager originalModelManager) {
 		this.basedir = basedir;
 		this.originalModelManager = originalModelManager;
-		this.evolvingModelManager = evolvingModelManager;
+		this.evolvingModelManager = new EdeltaModelManager();
 		this.mapOfCopiedEcores = evolvingModelManager.copyEcores(originalModelManager, basedir);
 		this.modelCopier = new EdeltaModelCopier(
 				mapOfCopiedEcores);
+	}
+
+	public EdeltaModelManager getEvolvingModelManager() {
+		return evolvingModelManager;
 	}
 
 	/**


### PR DESCRIPTION
We don't need basedir anymore: we use the original URI of the prototype resource