### PR TITLE
Edelta children

### DIFF
--- a/edelta.parent/edelta.example/edelta-gen/edelta/AnotherExample.java
+++ b/edelta.parent/edelta.example/edelta-gen/edelta/AnotherExample.java
@@ -12,8 +12,8 @@ public class AnotherExample extends EdeltaDefaultRuntime {
   
   public AnotherExample(final EdeltaRuntime other) {
     super(other);
-    example = new Example(other);
-    std = new EdeltaRefactorings(other);
+    example = new Example(this);
+    std = new EdeltaRefactorings(this);
   }
   
   @Override

--- a/edelta.parent/edelta.example/edelta-gen/edelta/Example.java
+++ b/edelta.parent/edelta.example/edelta-gen/edelta/Example.java
@@ -15,7 +15,7 @@ public class Example extends EdeltaDefaultRuntime {
   
   public Example(final EdeltaRuntime other) {
     super(other);
-    myfunctions = new ExampleReusableFunctions(other);
+    myfunctions = new ExampleReusableFunctions(this);
   }
   
   public void SomeChanges(final EPackage it) {

--- a/edelta.parent/edelta.example/edelta-gen/edelta/ExampleWithDuplicatedFeatureCheck.java
+++ b/edelta.parent/edelta.example/edelta-gen/edelta/ExampleWithDuplicatedFeatureCheck.java
@@ -16,7 +16,7 @@ public class ExampleWithDuplicatedFeatureCheck extends EdeltaDefaultRuntime {
   
   public ExampleWithDuplicatedFeatureCheck(final EdeltaRuntime other) {
     super(other);
-    checker = new EdeltaBadSmellsChecker(other);
+    checker = new EdeltaBadSmellsChecker(this);
   }
   
   public void someChanges(final EPackage it) {

--- a/edelta.parent/edelta.examples/edelta-gen/edelta/introducingdep/example/IntroducingDepModifExample.java
+++ b/edelta.parent/edelta.examples/edelta-gen/edelta/introducingdep/example/IntroducingDepModifExample.java
@@ -16,7 +16,7 @@ public class IntroducingDepModifExample extends EdeltaDefaultRuntime {
   
   public IntroducingDepModifExample(final EdeltaRuntime other) {
     super(other);
-    operations = new IntroducingDepOpExample(other);
+    operations = new IntroducingDepOpExample(this);
   }
   
   public void aModificationTest(final EPackage it) {

--- a/edelta.parent/edelta.examples/edelta-gen/edelta/personlist/example/PersonListExample.java
+++ b/edelta.parent/edelta.examples/edelta-gen/edelta/personlist/example/PersonListExample.java
@@ -19,7 +19,7 @@ public class PersonListExample extends EdeltaDefaultRuntime {
   
   public PersonListExample(final EdeltaRuntime other) {
     super(other);
-    refactorings = new EdeltaRefactorings(other);
+    refactorings = new EdeltaRefactorings(this);
   }
   
   public void improvePerson(final EPackage it) {

--- a/edelta.parent/edelta.examples/edelta-gen/edelta/petrinet/example/PetrinetExample.java
+++ b/edelta.parent/edelta.examples/edelta-gen/edelta/petrinet/example/PetrinetExample.java
@@ -20,7 +20,7 @@ public class PetrinetExample extends EdeltaDefaultRuntime {
   
   public PetrinetExample(final EdeltaRuntime other) {
     super(other);
-    refactorings = new EdeltaRefactorings(other);
+    refactorings = new EdeltaRefactorings(this);
   }
   
   public EAttribute addWeightAttribute(final EClass c) {

--- a/edelta.parent/edelta.maven.example/edelta-gen/com/example/Example.java
+++ b/edelta.parent/edelta.maven.example/edelta-gen/com/example/Example.java
@@ -18,8 +18,8 @@ public class Example extends EdeltaDefaultRuntime {
   
   public Example(final EdeltaRuntime other) {
     super(other);
-    refactorings = new EdeltaRefactorings(other);
-    myfunctions = new ExampleReusableFunctions(other);
+    refactorings = new EdeltaRefactorings(this);
+    myfunctions = new ExampleReusableFunctions(this);
   }
   
   public EClass createSubClassOfMyEClass(final String name) {

--- a/edelta.parent/edelta.refactorings.lib/edelta-lib-src-gen/edelta/refactorings/lib/EdeltaBadSmellsChecker.java
+++ b/edelta.parent/edelta.refactorings.lib/edelta-lib-src-gen/edelta/refactorings/lib/EdeltaBadSmellsChecker.java
@@ -17,7 +17,7 @@ public class EdeltaBadSmellsChecker extends EdeltaDefaultRuntime {
   
   public EdeltaBadSmellsChecker(final EdeltaRuntime other) {
     super(other);
-    finder = new EdeltaBadSmellsFinder(other);
+    finder = new EdeltaBadSmellsFinder(this);
   }
   
   /**

--- a/edelta.parent/edelta.refactorings.lib/edelta-lib-src-gen/edelta/refactorings/lib/EdeltaBadSmellsResolver.java
+++ b/edelta.parent/edelta.refactorings.lib/edelta-lib-src-gen/edelta/refactorings/lib/EdeltaBadSmellsResolver.java
@@ -24,8 +24,8 @@ public class EdeltaBadSmellsResolver extends EdeltaDefaultRuntime {
   
   public EdeltaBadSmellsResolver(final EdeltaRuntime other) {
     super(other);
-    refactorings = new EdeltaRefactorings(other);
-    finder = new EdeltaBadSmellsFinder(other);
+    refactorings = new EdeltaRefactorings(this);
+    finder = new EdeltaBadSmellsFinder(this);
   }
   
   /**

--- a/edelta.parent/edelta.testprojects.second/edelta-gen/com/example2/Example2.java
+++ b/edelta.parent/edelta.testprojects.second/edelta-gen/com/example2/Example2.java
@@ -17,7 +17,7 @@ public class Example2 extends EdeltaDefaultRuntime {
   
   public Example2(final EdeltaRuntime other) {
     super(other);
-    example1 = new Example1(other);
+    example1 = new Example1(this);
   }
   
   public void someModifications(final EPackage it) {

--- a/edelta.parent/edelta.tests/src/edelta/tests/EdeltaCompilerTest.xtend
+++ b/edelta.parent/edelta.tests/src/edelta/tests/EdeltaCompilerTest.xtend
@@ -426,7 +426,7 @@ class EdeltaCompilerTest extends EdeltaAbstractTest {
 			  
 			  public MyFile0(final EdeltaRuntime other) {
 			    super(other);
-			    my = new MyCustomEdelta(other);
+			    my = new MyCustomEdelta(this);
 			  }
 			  
 			  public void aTest(final EPackage it) {
@@ -467,7 +467,7 @@ class EdeltaCompilerTest extends EdeltaAbstractTest {
 			  
 			  public MyFile0(final EdeltaRuntime other) {
 			    super(other);
-			    my = new MyCustomEdelta(other);
+			    my = new MyCustomEdelta(this);
 			  }
 			  
 			  public void aTest(final EPackage it) {
@@ -516,8 +516,8 @@ class EdeltaCompilerTest extends EdeltaAbstractTest {
 			  
 			  public MyFile0(final EdeltaRuntime other) {
 			    super(other);
-			     = new MyCustomEdelta(other);
-			    my = new (other);
+			     = new MyCustomEdelta(this);
+			    my = new (this);
 			  }
 			  
 			  public void aTest(final EPackage it) {
@@ -1536,7 +1536,7 @@ class EdeltaCompilerTest extends EdeltaAbstractTest {
 				  
 				  public MyFile2(final EdeltaRuntime other) {
 				    super(other);
-				    my = new MyFile1(other);
+				    my = new MyFile1(this);
 				  }
 				  
 				  public void aModificationTest(final EPackage it) {
@@ -1881,7 +1881,7 @@ class EdeltaCompilerTest extends EdeltaAbstractTest {
 			  
 			  public Example(final EdeltaRuntime other) {
 			    super(other);
-			    refactorings = new EdeltaRefactorings(other);
+			    refactorings = new EdeltaRefactorings(this);
 			  }
 			  
 			  public void improvePerson(final EPackage it) {
@@ -2111,9 +2111,7 @@ class EdeltaCompilerTest extends EdeltaAbstractTest {
 		val edeltaObj = genClass
 			.getDeclaredConstructor(EdeltaRuntime)
 			.newInstance(mainEdelta) as EdeltaRuntime
-		// we must pass the mainEdelta so that the issue presented
-		// is correctly propagated to the child edeltaObj
-		instanceConsumer.accept(mainEdelta)
+		instanceConsumer.accept(edeltaObj)
 		// load ecore files
 		for (ecoreName : ecoreNames) {
 			modelManager.loadEcoreFile(METAMODEL_PATH + ecoreName)

--- a/edelta.parent/edelta/src/edelta/jvmmodel/EdeltaJvmModelInferrer.xtend
+++ b/edelta.parent/edelta/src/edelta/jvmmodel/EdeltaJvmModelInferrer.xtend
@@ -72,7 +72,7 @@ class EdeltaJvmModelInferrer extends AbstractModelInferrer {
 				body = '''
 				super(other);
 				«FOR u : program.useAsClauses»
-				«u.name» = new «u.type»(other);
+				«u.name» = new «u.type»(this);
 				«ENDFOR»
 				'''
 			]


### PR DESCRIPTION
The generated code passes "this" instead of "other" when creating the fields for used libraries.
This makes much more sense than it was before